### PR TITLE
fixed inverse canonicalization key issue group -> group_element

### DIFF
--- a/equiadapt/images/canonicalization/discrete_group.py
+++ b/equiadapt/images/canonicalization/discrete_group.py
@@ -55,7 +55,7 @@ class DiscreteGroupImageCanonicalization(DiscreteGroupCanonicalization):
             len(in_shape) == 3
         ), "Input shape should be in the format (channels, height, width)"
 
-        # DEfine all the image transformations here which are used during canonicalization
+        # Define all the image transformations here which are used during canonicalization
         # pad and crop the input image if it is not rotated MNIST
         is_grayscale = in_shape[0] == 1
 
@@ -254,7 +254,7 @@ class DiscreteGroupImageCanonicalization(DiscreteGroupCanonicalization):
         return get_action_on_image_features(
             feature_map=x_canonicalized_out,
             group_info_dict=self.group_info_dict,
-            group_element_dict=self.canonicalization_info_dict,  # type: ignore
+            group_element_dict=self.canonicalization_info_dict["group_element"],  # type: ignore
             induced_rep_type=induced_rep_type,
         )
 

--- a/equiadapt/images/canonicalization/discrete_group.py
+++ b/equiadapt/images/canonicalization/discrete_group.py
@@ -254,7 +254,7 @@ class DiscreteGroupImageCanonicalization(DiscreteGroupCanonicalization):
         return get_action_on_image_features(
             feature_map=x_canonicalized_out,
             group_info_dict=self.group_info_dict,
-            group_element_dict=self.canonicalization_info_dict["group_element"],  # type: ignore
+            group_element_dict=self.canonicalization_info_dict,  # type: ignore
             induced_rep_type=induced_rep_type,
         )
 

--- a/equiadapt/images/utils.py
+++ b/equiadapt/images/utils.py
@@ -53,11 +53,11 @@ def get_action_on_image_features(
     batch_size, C, H, W = feature_map.shape
     if induced_rep_type == "regular":
         assert feature_map.shape[1] % num_group == 0
-        angles = group_element_dict["group_element"]["rotation"]
+        angles = group_element_dict["rotation"]
         x_out = K.geometry.rotate(feature_map, angles)
 
-        if "reflection" in group_element_dict["group_element"]:
-            reflect_indicator = group_element_dict["group_element"]["reflection"]
+        if "reflection" in group_element_dict:
+            reflect_indicator = group_element_dict["reflection"]
             x_out_reflected = K.geometry.hflip(x_out)
             x_out = x_out * reflect_indicator[:, None, None, None] + x_out_reflected * (
                 1 - reflect_indicator[:, None, None, None]
@@ -65,7 +65,7 @@ def get_action_on_image_features(
 
         x_out = x_out.reshape(batch_size, C // num_group, num_group, H, W)
         shift = angles / 360.0 * num_rotations
-        if "reflection" in group_element_dict["group_element"]:
+        if "reflection" in group_element_dict:
             x_out = torch.cat(
                 [
                     roll_by_gather(x_out[:, :, :num_rotations], shift),
@@ -78,10 +78,10 @@ def get_action_on_image_features(
         x_out = x_out.reshape(batch_size, -1, H, W)
         return x_out
     elif induced_rep_type == "scalar":
-        angles = group_element_dict["group_element"]["rotation"]
+        angles = group_element_dict["rotation"]
         x_out = K.geometry.rotate(feature_map, angles)
-        if "reflection" in group_element_dict["group_element"]:
-            reflect_indicator = group_element_dict["group_element"]["reflection"]
+        if "reflection" in group_element_dict:
+            reflect_indicator = group_element_dict["reflection"]
             x_out_reflected = K.geometry.hflip(x_out)
             x_out = x_out * reflect_indicator[:, None, None, None] + x_out_reflected * (
                 1 - reflect_indicator[:, None, None, None]

--- a/equiadapt/images/utils.py
+++ b/equiadapt/images/utils.py
@@ -53,11 +53,11 @@ def get_action_on_image_features(
     batch_size, C, H, W = feature_map.shape
     if induced_rep_type == "regular":
         assert feature_map.shape[1] % num_group == 0
-        angles = group_element_dict["group"]["rotation"]
+        angles = group_element_dict["group_element"]["rotation"]
         x_out = K.geometry.rotate(feature_map, angles)
 
-        if "reflection" in group_element_dict["group"]:
-            reflect_indicator = group_element_dict["group"]["reflection"]
+        if "reflection" in group_element_dict["group_element"]:
+            reflect_indicator = group_element_dict["group_element"]["reflection"]
             x_out_reflected = K.geometry.hflip(x_out)
             x_out = x_out * reflect_indicator[:, None, None, None] + x_out_reflected * (
                 1 - reflect_indicator[:, None, None, None]
@@ -65,7 +65,7 @@ def get_action_on_image_features(
 
         x_out = x_out.reshape(batch_size, C // num_group, num_group, H, W)
         shift = angles / 360.0 * num_rotations
-        if "reflection" in group_element_dict["group"]:
+        if "reflection" in group_element_dict["group_element"]:
             x_out = torch.cat(
                 [
                     roll_by_gather(x_out[:, :, :num_rotations], shift),
@@ -78,10 +78,10 @@ def get_action_on_image_features(
         x_out = x_out.reshape(batch_size, -1, H, W)
         return x_out
     elif induced_rep_type == "scalar":
-        angles = group_element_dict["group"][0]
+        angles = group_element_dict["group_element"][0]
         x_out = K.geometry.rotate(feature_map, angles)
-        if "reflection" in group_element_dict["group"]:
-            reflect_indicator = group_element_dict["group"]["reflection"]
+        if "reflection" in group_element_dict["group_element"]:
+            reflect_indicator = group_element_dict["group_element"]["reflection"]
             x_out_reflected = K.geometry.hflip(x_out)
             x_out = x_out * reflect_indicator[:, None, None, None] + x_out_reflected * (
                 1 - reflect_indicator[:, None, None, None]

--- a/equiadapt/images/utils.py
+++ b/equiadapt/images/utils.py
@@ -78,7 +78,7 @@ def get_action_on_image_features(
         x_out = x_out.reshape(batch_size, -1, H, W)
         return x_out
     elif induced_rep_type == "scalar":
-        angles = group_element_dict["group_element"][0]
+        angles = group_element_dict["group_element"]["rotation"]
         x_out = K.geometry.rotate(feature_map, angles)
         if "reflection" in group_element_dict["group_element"]:
             reflect_indicator = group_element_dict["group_element"]["reflection"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -83,6 +83,7 @@ norecursedirs =
     build
     .tox
 testpaths = tests
+filterwarnings = ignore::Warning
 # Use pytest markers to select/deselect specific tests
 # markers =
 #     slow: mark tests as slow (deselect with '-m "not slow"')

--- a/tests/images/canonicalization/test_discrete_group.py
+++ b/tests/images/canonicalization/test_discrete_group.py
@@ -1,0 +1,69 @@
+import pytest
+import torch
+from omegaconf import DictConfig
+
+from equiadapt.images.canonicalization.discrete_group import (
+    GroupEquivariantImageCanonicalization,
+)
+from equiadapt.images.canonicalization_networks.escnn_networks import (
+    ESCNNEquivariantNetwork,
+)
+
+
+@pytest.fixture
+def init_args() -> dict:
+    """
+    Initialize the arguments for the canonicalization function.
+
+    Returns:
+        dict: A dictionary containing the initialization arguments.
+    """
+    # Mock initialization arguments
+    canonicalization_hyperparams = DictConfig(
+        {
+            "input_crop_ratio": 0.9,
+            "resize_shape": (32, 32),
+            "beta": 0.1,
+        }
+    )
+    return {
+        "canonicalization_network": ESCNNEquivariantNetwork(
+            in_shape=(3, 64, 64),
+            out_channels=32,
+            kernel_size=3,
+            group_type="rotation",
+            num_rotations=4,
+            num_layers=2,
+        ),
+        "canonicalization_hyperparams": canonicalization_hyperparams,
+        "in_shape": (3, 64, 64),
+    }
+
+
+# try both types of induced representations (regular and scalar)
+@pytest.mark.parametrize("induced_rep, num_channels", [("regular", 12), ("scalar", 3)])
+def test_invert_canonicalization_induced_rep(
+    induced_rep: str, num_channels: int, init_args: dict
+) -> None:
+    """
+    Test the inversion of the canonicalization-induced representation.
+
+    Args:
+        induced_rep (str): The type of induced representation.
+        num_channels (int): The number of channels in the sample image.
+    """
+
+    # Initialize the canonicalization function
+    dgic = GroupEquivariantImageCanonicalization(**init_args)
+
+    # Apply the canonicalization function
+    image = torch.randn((1, 3, 64, 64))
+
+    _ = dgic(image)  # to populate the canonicalization_info_dict
+
+    canonicalized_image = torch.randn((1, num_channels, 64, 64))
+
+    # Invert the canonicalization-induced representation
+    inverted_image = dgic.invert_canonicalization(
+        canonicalized_image, **{"induced_rep_type": induced_rep}
+    )


### PR DESCRIPTION
Issue #16 
`inverse_canonicalziation` was throwing KeyError because it was searching for a key element named `group` in the `canonicalization_info_dict` dictionary. However, this key is called `group_element`.
Furthermore, the full dictionary was not being passed to the `get_action_on_image_features` function.

Now, the full nested dictionary is being passed, and the key has been replaced from `group` to `group_element`.