### PR TITLE
[Change] OS used to test python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,14 +58,16 @@ jobs:
   test:
     needs: prepare
     strategy:
+      fail-fast: false
       matrix:
-        python:
-        - "3.7"  # oldest Python supported by PSF
-        - "3.12"  # newest Python that is stable
-        platform:
-        - ubuntu-latest
-        - macos-latest
-        - windows-latest
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
+          - python-version: "3.7"
+            os: macos-latest
+        include:  # So run those legacy versions on Intel CPUs.
+          - python-version: "3.7"
+            os: macos-13
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,14 +60,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        platform: [ubuntu-latest, macos-latest, windows-latest]
         exclude:  # Python < v3.8 does not support Apple Silicon ARM64.
-          - python-version: "3.7"
-            os: macos-latest
+          - python: "3.7"
+            platform: macos-latest
         include:  # So run those legacy versions on Intel CPUs.
-          - python-version: "3.7"
-            os: macos-13
+          - python: "3.7"
+            platform: macos-13
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated `CONTRIBUTING.md` with more information on how to run the code checks.
+- Changed the OS used to test Python 3.7 on GitHub actions (macos-latest -> macos-13).
 
 ### Removed
 


### PR DESCRIPTION
# Description

The aim is to fix tests failing due to changes in the `macos-latest` GitHub actions runner: https://github.com/actions/setup-python/issues/856

# Proposed Changes

I changed the GitHub actions file following this example https://github.com/actions/runner-images/issues/9770#issuecomment-2085623315

# Checklist

Here are some things to check before creating the pull request. If you encounter any issues, don't hesitate to ask for help :)

- [x] I have read the [contributor's guide](https://github.com/arnab39/equiadapt/blob/main/CONTRIBUTING.md).
- [x] The base branch of my pull request is the `dev` branch, not the `main` branch.
- [x] I ran the [code checks](https://github.com/arnab39/equiadapt/blob/main/CONTRIBUTING.md#implement-your-changes) on the files I added or modified and fixed the errors.
- [x] I updated the [changelog](https://github.com/arnab39/equiadapt/blob/main/CHANGELOG.md).

